### PR TITLE
Changed browser to be global context to preserve session between flows

### DIFF
--- a/src/wdio-common.js
+++ b/src/wdio-common.js
@@ -2,7 +2,7 @@ const wdio = require('webdriverio')
 let newSessionNode
 
 module.exports.getBrowser = (context) => {
-  let browser = context.flow.get('wdio_browser')
+  let browser = context.global.get('wdio_browser')
   if (!browser || !browser.sessionId)
     throw new Error('No session defined - call newSession first')
 
@@ -28,7 +28,7 @@ module.exports.newSession = async (config, node, context) => {
   let browser
   try {
     browser = await wdio.remote(config)
-    context.flow.set('wdio_browser', browser)
+    context.global.set('wdio_browser', browser)
     newSessionNode = node
   } catch (e) {
     throw e
@@ -38,12 +38,12 @@ module.exports.newSession = async (config, node, context) => {
 
 module.exports.deleteSession = async (context) => {
   let b
-  let browser = context.flow.get('wdio_browser')
+  let browser = context.global.get('wdio_browser')
   try {
     b = { sessionId: browser.sessionId }
     await browser.closeWindow()
     await browser.deleteSession()
-    context.flow.set('wdio_browser', null)
+    context.global.set('wdio_browser', null)
     if (newSessionNode) module.exports.disconnected(newSessionNode)
   } catch (e) {}
   return b


### PR DESCRIPTION
Update made to wdio-common.js

Currently, the browser session was being lost when jumping from one node-red flow to another. The current p360 GUI automation relies of the browser session being preserved 