### PR TITLE
Added Firefox and MicrosoftEdge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-red-contrib-wdio",
   "description": "WebdriverIO nodes for Node-RED",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "author": "rmbrich",
   "license": "MIT",
   "repository": {

--- a/src/new-session.html
+++ b/src/new-session.html
@@ -30,7 +30,7 @@
     inputs: 1,
     outputs: 1,
     icon: 'white-globe.png',
-    label: function() {
+    label: function () {
       return this.name || 'new session'
     }
   })
@@ -49,11 +49,13 @@
       <input id="node-input-webdriverUri" type="text" placeholder="https://host:port/path">
   </div>
   <div class="form-row" id="row-browser">
-      <label for="node-input-webdriverBrowser"><i class="fa fa-globe"></i> Browser</label>
-      <select type="text" id="node-input-webdriverBrowser" style="width:70%;">
-          <option value="chrome" selected>Chrome</option>
-          <option value="chromium">Chromium</option>
-      </select>
+    <label for="node-input-webdriverBrowser"><i class="fa fa-globe"></i> Browser</label>
+    <select type="text" id="node-input-webdriverBrowser" style="width:70%;">
+        <option value="chrome" selected>Chrome</option>
+        <option value="chromium">Chromium</option>
+        <option value="firefox">Firefox</option>
+        <option value="MicrosoftEdge">MicrosoftEdge</option>
+    </select>
   </div>
   <div class="form-row">
       <label for="node-input-logLevel"><i class="fa fa-tasks"></i> Log Level</label>

--- a/src/new-session.js
+++ b/src/new-session.js
@@ -87,6 +87,17 @@ const getCapabilities = (vendor, browser) => {
         w3c: false
       }
     }
+  } else if (vendor === 'local' && browser === 'firefox') {
+    capabilities = {
+      browserName: 'firefox'
+    }
+  } else if (vendor === 'local' && browser === 'MicrosoftEdge') {
+    capabilities = {
+      browserName: 'MicrosoftEdge',
+      'ms:edgeOptions': {
+        args: ['--remote-allow-origins=*']
+      }
+    }
   } else if (vendor === 'local') {
     capabilities = {
       browserName: browser,


### PR DESCRIPTION
This branch adds Firefox and MicrosoftEdge options to the 'node-red-contrib-wdio: new-session'. Existing chrome and chromium options were not touched.